### PR TITLE
fix: [DEV-22] resolve inconsistent order of party data

### DIFF
--- a/app/parse/party.go
+++ b/app/parse/party.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"sort"
 
 	"ba-torment-data-process/app/common"
 	"ba-torment-data-process/app/logic"
@@ -28,8 +29,13 @@ func ParsePartyDataFromAronaAI(seasonString string) (*types.BATormentPartyData, 
 	minPartys := 99
 	maxPartys := 0
 
-	for _, rankData := range aronaAIData.D {
-		rank := rankData.R
+	// 점수 기준으로 내림차순 정렬 (높은 점수부터)
+	sort.Slice(aronaAIData.D, func(i, j int) bool {
+		return aronaAIData.D[i].S > aronaAIData.D[j].S
+	})
+
+	for i, rankData := range aronaAIData.D {
+		rank := i + 1 // 정렬된 순서대로 순위 부여 (1위부터)
 		score := rankData.S
 
 		partyData := make([][6]int, len(rankData.T))

--- a/cmd/v3_migrate/migrate.go
+++ b/cmd/v3_migrate/migrate.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 )
 
@@ -108,9 +109,14 @@ func convertPartyData(oldParties []OldPartyData) ([]NewPartyData, int, int) {
 	minPartys := 99
 	maxPartys := 0
 
-	for _, party := range oldParties {
+	// 점수 기준으로 내림차순 정렬 (높은 점수부터)
+	sort.Slice(oldParties, func(i, j int) bool {
+		return oldParties[i].Score > oldParties[j].Score
+	})
+
+	for i, party := range oldParties {
 		newParty := NewPartyData{
-			Rank:      party.FinalRank,
+			Rank:      i + 1, // 정렬된 순서대로 순위 부여 (1위부터)
 			Score:     party.Score,
 			PartyData: make([][]int, 0),
 		}


### PR DESCRIPTION
## What changed on this pull request

Fixed inconsistent order of party data.
It seems that invalid usage of `range` causes the wrong order of the array,
and the old data was remaining invalid.

Migration script is run for all data, and it seems to be resolved.
