### PR TITLE
refactor: Replace storage panics with error returns

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,9 +12,12 @@
 name: "CodeQL Advanced"
 
 on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
   schedule:
     - cron: "30 4 * * 0"
-  workflow_dispatch:
 
 jobs:
   analyze:

--- a/.gitignore
+++ b/.gitignore
@@ -1,18 +1,20 @@
-# Environment variables
 .env*
+.DS_Store
 
-# Binary
+.vscode/
+
+# Build dependencies & artifact binaries
+dist/
+vendor/
 batorment
 batorment.exe
 
-# Test files
-/app/tests/files/*
-
-# Arona AI formatted data
-/data
+# Temporary & test data
+.agent-cache/
+.agent-check-result.json
 
 # DuckDB database
 *.db
 
-# Temp files
-.DS_store
+# Arona AI formatted data
+/data

--- a/internal/logic/gridimage/generate.go
+++ b/internal/logic/gridimage/generate.go
@@ -107,7 +107,10 @@ func GenerateGridImages(dryRun bool) error {
 
 func fetchAllStudents() ([]StudentInfo, error) {
 	url := supabaseBaseURL + "/batorment/v3/total-analysis.json"
-	data := storage.GetDataFromURL(url)
+	data, err := storage.GetDataFromURL(url)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch total-analysis: %w", err)
+	}
 
 	var analysis types.TotalAnalysisOutput
 	if err := json.Unmarshal(data, &analysis); err != nil {
@@ -223,7 +226,10 @@ func generateGrid(students []StudentInfo) (image.Image, error) {
 
 func fetchPortraitFromSupabase(studentID int) (image.Image, error) {
 	url := supabaseBaseURL + "/batorment/character/" + strconv.Itoa(studentID) + ".webp"
-	data := storage.GetDataFromURL(url)
+	data, err := storage.GetDataFromURL(url)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch portrait %d: %w", studentID, err)
+	}
 
 	img, _, err := image.Decode(bytes.NewReader(data))
 	if err != nil {

--- a/internal/logic/schaledb/i18n.go
+++ b/internal/logic/schaledb/i18n.go
@@ -18,22 +18,34 @@ type localizationRaw struct {
 	Club   map[string]string `json:"Club"`
 }
 
-func loadLocalizationFull(lang string) *localizationRaw {
+func loadLocalizationFull(lang string) (*localizationRaw, error) {
 	url := constants.SchaleDBURL + "data/" + lang + "/localization.min.json"
-	byteValue := storage.GetDataFromURL(url)
+	byteValue, err := storage.GetDataFromURL(url)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch localization (%s): %w", lang, err)
+	}
 
 	var data localizationRaw
 	if err := json.Unmarshal(byteValue, &data); err != nil {
-		panic(fmt.Sprintf("Failed to unmarshal localization (%s): %v", lang, err))
+		return nil, fmt.Errorf("failed to unmarshal localization (%s): %w", lang, err)
 	}
 
-	return &data
+	return &data, nil
 }
 
 func SaveI18nData(db *postgres.Queries) error {
-	kr := loadLocalizationFull("kr")
-	ja := loadLocalizationFull("jp")
-	en := loadLocalizationFull("en")
+	kr, err := loadLocalizationFull("kr")
+	if err != nil {
+		return err
+	}
+	ja, err := loadLocalizationFull("jp")
+	if err != nil {
+		return err
+	}
+	en, err := loadLocalizationFull("en")
+	if err != nil {
+		return err
+	}
 
 	ctx := context.Background()
 

--- a/internal/logic/schaledb/presents.go
+++ b/internal/logic/schaledb/presents.go
@@ -11,21 +11,26 @@ import (
 )
 
 // Reads /data/<lang>/items.json file
-func loadItems(lang string) map[string]types.FavorItem {
+func loadItems(lang string) (map[string]types.FavorItem, error) {
 	url := fmt.Sprintf("%s/data/%s/items.json", constants.SchaleDBURL, lang)
-	byteValue := storage.GetDataFromURL(url)
-
-	var items map[string]types.FavorItem
-	err := json.Unmarshal(byteValue, &items)
+	byteValue, err := storage.GetDataFromURL(url)
 	if err != nil {
-		panic(fmt.Sprintf("Failed to unmarshal localization: %v", err))
+		return nil, fmt.Errorf("failed to fetch items (%s): %w", lang, err)
 	}
 
-	return items
+	var items map[string]types.FavorItem
+	if err := json.Unmarshal(byteValue, &items); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal items (%s): %w", lang, err)
+	}
+
+	return items, nil
 }
 
 func ParseSchaleDBPresents(db *postgres.Queries) (map[string]*types.FavorItem, error) {
-	items := loadItems("kr")
+	items, err := loadItems("kr")
+	if err != nil {
+		return nil, err
+	}
 
 	for _, item := range items {
 		db.InsertPresent(context.Background(), postgres.InsertPresentParams{

--- a/internal/logic/schaledb/students.go
+++ b/internal/logic/schaledb/students.go
@@ -29,31 +29,35 @@ type JapaneseStudentInfo struct {
 }
 
 // Reads /data/<lang>/localization.min.json file and returns BuffName map
-func loadLocalization(lang string) map[string]string {
+func loadLocalization(lang string) (map[string]string, error) {
 	url := fmt.Sprintf("%s/data/%s/localization.min.json", constants.SchaleDBURL, lang)
-	byteValue := storage.GetDataFromURL(url)
-
-	var locData LocalizationRawData
-	err := json.Unmarshal(byteValue, &locData)
+	byteValue, err := storage.GetDataFromURL(url)
 	if err != nil {
-		panic(fmt.Sprintf("Failed to unmarshal localization: %v", err))
+		return nil, fmt.Errorf("failed to fetch localization (%s): %w", lang, err)
 	}
 
-	return locData.BuffName
+	var locData LocalizationRawData
+	if err := json.Unmarshal(byteValue, &locData); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal localization (%s): %w", lang, err)
+	}
+
+	return locData.BuffName, nil
 }
 
 // Reads /data/jp/students.json file and returns Japanese student info map.
 // This is used to get student names in Japanese.
-func loadJapaneseStudentInfo() map[string]JapaneseStudentInfo {
-	byteValue := storage.GetDataFromURL(constants.SchaleDBURL + "/data/jp/students.json")
-
-	var studentData map[string]JapaneseStudentInfo
-	err := json.Unmarshal(byteValue, &studentData)
+func loadJapaneseStudentInfo() (map[string]JapaneseStudentInfo, error) {
+	byteValue, err := storage.GetDataFromURL(constants.SchaleDBURL + "/data/jp/students.json")
 	if err != nil {
-		panic(fmt.Sprintf("Failed to unmarshal student data: %v", err))
+		return nil, fmt.Errorf("failed to fetch japanese student info: %w", err)
 	}
 
-	return studentData
+	var studentData map[string]JapaneseStudentInfo
+	if err := json.Unmarshal(byteValue, &studentData); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal japanese student info: %w", err)
+	}
+
+	return studentData, nil
 }
 
 // replaceBuffTags replaces <b:> and <d:> tags in skill descriptions with Korean names
@@ -195,16 +199,24 @@ func processSkillDesc(skillMap map[string]any, buffNames map[string]string) {
 // ParseSchaleDBStudents parses SchaleDB data and returns processed student data
 func ParseSchaleDBStudents(db *postgres.Queries) (map[string]*types.StudentData, error) {
 
-	byteValue := storage.GetDataFromURL(constants.SchaleDBURL + "/data/kr/students.json")
-
-	var rawData map[string]any
-	err := json.Unmarshal(byteValue, &rawData)
+	byteValue, err := storage.GetDataFromURL(constants.SchaleDBURL + "/data/kr/students.json")
 	if err != nil {
-		panic(fmt.Sprintf("Failed to unmarshal JSON: %v", err))
+		return nil, fmt.Errorf("failed to fetch students: %w", err)
 	}
 
-	buffNames := loadLocalization("kr")
-	japaneseStudentInfo := loadJapaneseStudentInfo()
+	var rawData map[string]any
+	if err := json.Unmarshal(byteValue, &rawData); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal students: %w", err)
+	}
+
+	buffNames, err := loadLocalization("kr")
+	if err != nil {
+		return nil, err
+	}
+	japaneseStudentInfo, err := loadJapaneseStudentInfo()
+	if err != nil {
+		return nil, err
+	}
 
 	result := make(map[string]*types.StudentData)
 	studentMap := make(map[string]string)
@@ -328,14 +340,15 @@ func ParseSchaleDBStudents(db *postgres.Queries) (map[string]*types.StudentData,
 
 // Uploads the character image from SchaleDB via File Manager API.
 func uploadCharacterImage(id int, dryRun bool) error {
-
-	imgBytes := storage.GetDataFromURL(constants.SchaleDBURL + "images/student/icon/" + strconv.Itoa(id) + ".webp")
+	imgBytes, err := storage.GetDataFromURL(constants.SchaleDBURL + "images/student/icon/" + strconv.Itoa(id) + ".webp")
+	if err != nil {
+		return fmt.Errorf("failed to fetch character image %d: %w", id, err)
+	}
 
 	path := "batorment/character"
 
-	err := storage.UploadFile(path, strconv.Itoa(id)+".webp", imgBytes, dryRun)
-	if err != nil {
-		return fmt.Errorf("failed to upload image to S3: %v", err)
+	if err := storage.UploadFile(path, strconv.Itoa(id)+".webp", imgBytes, dryRun); err != nil {
+		return fmt.Errorf("failed to upload image to S3: %w", err)
 	}
 
 	return nil

--- a/internal/logic/storage/download.go
+++ b/internal/logic/storage/download.go
@@ -13,14 +13,21 @@ import (
 
 const maxRetries = 3
 
-// GetDataFromURL gets data from URL with retry on transient errors.
-func GetDataFromURL(url string) []byte {
+// GetDataFromURL gets data from URL with retry on transient (5xx) errors.
+func GetDataFromURL(url string) ([]byte, error) {
 	start := time.Now()
 
+	var lastErr error
 	for attempt := range maxRetries {
 		resp, err := http.Get(url)
 		if err != nil {
-			panic(fmt.Sprintf("failed to get data from URL: %v", err))
+			lastErr = fmt.Errorf("http get failed: %w", err)
+			if attempt < maxRetries-1 {
+				ui.Log.Warn("Retrying request after transport error", logger.F("url", url), logger.F("attempt", attempt+1), logger.F("err", err.Error()))
+				time.Sleep(2 * time.Second)
+				continue
+			}
+			return nil, lastErr
 		}
 
 		if resp.StatusCode >= 500 && attempt < maxRetries-1 {
@@ -32,20 +39,24 @@ func GetDataFromURL(url string) []byte {
 
 		if resp.StatusCode != 200 {
 			resp.Body.Close()
-			panic(fmt.Sprintf("invalid status code: %d, URL: %s", resp.StatusCode, url))
+			return nil, fmt.Errorf("unexpected status %d for URL: %s", resp.StatusCode, url)
 		}
 
 		body, err := io.ReadAll(resp.Body)
 		resp.Body.Close()
 		if err != nil {
-			panic(fmt.Sprintf("failed to read data from URL: %v", err))
-		} else if len(body) == 0 {
-			panic(fmt.Sprintf("the data from URL is empty: %s", url))
+			return nil, fmt.Errorf("failed to read response body: %w", err)
+		}
+		if len(body) == 0 {
+			return nil, fmt.Errorf("empty response body for URL: %s", url)
 		}
 
 		ui.Log.Info("Response successfully fetched", logger.F("url", url), logger.F("duration", time.Since(start)))
-		return body
+		return body, nil
 	}
 
-	panic(fmt.Sprintf("unreachable: max retries exceeded for URL: %s", url))
+	if lastErr != nil {
+		return nil, lastErr
+	}
+	return nil, fmt.Errorf("max retries exceeded for URL: %s", url)
 }

--- a/internal/logic/storage/upload.go
+++ b/internal/logic/storage/upload.go
@@ -59,10 +59,10 @@ func UploadFile(path string, fileName string, data []byte, dryRun bool) error {
 
 	part, err := writer.CreateFormFile("file", fileName)
 	if err != nil {
-		panic(fmt.Sprintf("Failed to create form file: %v", err))
+		return fmt.Errorf("failed to create form file: %w", err)
 	}
 	if _, err := io.Copy(part, bytes.NewReader(data)); err != nil {
-		panic(fmt.Sprintf("Failed to copy file data: %v", err))
+		return fmt.Errorf("failed to copy file data: %w", err)
 	}
 	writer.WriteField("upload_path", path)
 	writer.Close()
@@ -73,7 +73,7 @@ func UploadFile(path string, fileName string, data []byte, dryRun bool) error {
 		body,
 	)
 	if err != nil {
-		panic(fmt.Sprintf("API request failed: %v", err))
+		return fmt.Errorf("failed to build upload request: %w", err)
 	}
 
 	req.Header.Set("X-Access-Token", env.GetEnv("BA_ANALYZER_SERVICE_TOKEN", ""))
@@ -82,13 +82,13 @@ func UploadFile(path string, fileName string, data []byte, dryRun bool) error {
 	client := &http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {
-		panic(fmt.Sprintf("API request failed: %v", err))
+		return fmt.Errorf("upload request failed: %w", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		panic(fmt.Sprintf("failed to upload image: status %d, body: %s", resp.StatusCode, string(body)))
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("upload failed: status %d, body: %s", resp.StatusCode, string(respBody))
 	}
 
 	ui.Log.Info("File uploaded successfully", logger.F("file", fileName))

--- a/internal/types/analysis_types.go
+++ b/internal/types/analysis_types.go
@@ -45,14 +45,14 @@ type CharacterSynergy struct {
 
 // CharacterAnalysisResult represents analysis result for a single character
 type CharacterAnalysisResult struct {
-	StudentID        int                  `json:"studentId"`
-	UsageHistory     []RaidUsage          `json:"usageHistory"`
+	StudentID        int                   `json:"studentId"`
+	UsageHistory     []RaidUsage           `json:"usageHistory"`
 	StarDistribution *RaidStarDistribution `json:"starDistribution"` // Latest distribution (200+ usage), null if none
-	AssistStats      AssistUsageStats     `json:"assistStats"`
-	TopSynergyChars  []CharacterSynergy   `json:"topSynergyChars"`
-	TotalUsage       int                  `json:"totalUsage"`
-	OverallRank      int                  `json:"overallRank"`
-	CategoryRank     int                  `json:"categoryRank"`
+	AssistStats      AssistUsageStats      `json:"assistStats"`
+	TopSynergyChars  []CharacterSynergy    `json:"topSynergyChars"`
+	TotalUsage       int                   `json:"totalUsage"`
+	OverallRank      int                   `json:"overallRank"`
+	CategoryRank     int                   `json:"categoryRank"`
 }
 
 // TotalAnalysisOutput represents the final output of total analysis

--- a/internal/types/schaledb_students.go
+++ b/internal/types/schaledb_students.go
@@ -81,10 +81,10 @@ type StudentSkills struct {
 
 // Individual skill
 type StudentSkill struct {
-	Cost        []int          `json:"Cost,omitempty"`
-	Desc        string         `json:"Desc"`
-	Effects     []SkillEffect  `json:"Effects"`
-	ExtraSkills []ExtraSkill   `json:"ExtraSkills,omitempty"`
+	Cost        []int         `json:"Cost,omitempty"`
+	Desc        string        `json:"Desc"`
+	Effects     []SkillEffect `json:"Effects"`
+	ExtraSkills []ExtraSkill  `json:"ExtraSkills,omitempty"`
 }
 
 // Extra skill for selectable EX skills


### PR DESCRIPTION
## What changed on this pull request

- Replace panics in storage layer (`UploadFile`, `GetDataFromURL`) with error returns
- Adapt all schaledb / gridimage callers to propagate errors
