### PR TITLE
fix(party): switch DuckDB source URL from /v1/ to /v2/

### DIFF
--- a/internal/logic/party/parse.go
+++ b/internal/logic/party/parse.go
@@ -27,7 +27,7 @@ func downloadDuckDB(dateString string) error {
 		return fmt.Errorf("BATORMENT_DUCKDB_REMOTE_URL environment variable is not set")
 	}
 
-	url := fmt.Sprintf("%s/v1/JP/%s.db", baseURL, dateString)
+	url := fmt.Sprintf("%s/v2/JP/%s.db", baseURL, dateString)
 	fileName := fmt.Sprintf("%s.db", dateString)
 
 	ui.Log.Info("Downloading DuckDB", logger.F("url", url))


### PR DESCRIPTION
## Why

The CDN's `/v1/JP/` path is no longer published for recent raids; `/v2/JP/` has replaced it and back-fills older dates. `process-raid` currently 403s on every new raid.

## What

`internal/logic/party/parse.go` switches the downloader to `/v2/JP/{date}.db`. No SQL changes.

## Evidence

### Checks
- stack: go-workflow
- base: origin/main
- commit: 02e96f7
- scope: whole-repo
- status: pass
- failures: none

### CDN availability (HEAD)
| date | content | v1 | v2 |
|---|---|---|---|
| 20260513 | 3S33-3 | 403 | 200 |
| 20260429 | S88-0  | 200 | 200 |
| 20260408 | 3S32-4 | 200 | 200 |

### Schema compatibility
v2 is a superset of v1:
- `complete_runs` adds `rank UINTEGER` (existing `point`, `<armor>_point` preserved)
- `students[_armor]` adds `mulligan BOOLEAN`
- New aggregate tables: `difficulty_stats` / `combined_difficulty_stats`

Existing queries in `internal/logic/party/sql.go` select only legacy columns and tables, so they continue to work unchanged on v2.
