### PR TITLE
chore(ci): replace build.sh with multi-arch GHCR action

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,93 @@
+name: Build and Push Docker Image
+
+on:
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: beaverhouse/ba-data-process
+
+jobs:
+  generate-sha:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      sha: ${{ steps.commit-sha.outputs.sha }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: commit-sha
+        run: echo "sha=$(git rev-parse --short=8 HEAD)" >> $GITHUB_OUTPUT
+
+  build-amd64:
+    runs-on: ubuntu-latest
+    needs: generate-sha
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64
+          push: true
+          provenance: false
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.generate-sha.outputs.sha }}-amd64
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache-amd64
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache-amd64,mode=max
+          secrets: |
+            gitlab_token=${{ secrets.GITLAB_TOKEN }}
+
+  build-arm64:
+    runs-on: ubuntu-24.04-arm
+    needs: generate-sha
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/arm64
+          push: true
+          provenance: false
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.generate-sha.outputs.sha }}-arm64
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache-arm64
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache-arm64,mode=max
+          secrets: |
+            gitlab_token=${{ secrets.GITLAB_TOKEN }}
+
+  create-manifest:
+    runs-on: ubuntu-latest
+    needs: [generate-sha, build-amd64, build-arm64]
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create and push multi-arch manifest
+        run: |
+          SHA=${{ needs.generate-sha.outputs.sha }}
+          IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          docker manifest create ${IMAGE}:${SHA} \
+            ${IMAGE}:${SHA}-amd64 \
+            ${IMAGE}:${SHA}-arm64
+          docker manifest push ${IMAGE}:${SHA}

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,0 @@
-tag=v0.1.9
-
-docker build -t ghcr.io/beaverhouse/ba-data-process:$tag .
-docker push ghcr.io/beaverhouse/ba-data-process:$tag


### PR DESCRIPTION
## Why

`build.sh` only builds amd64 from a local machine and pushes to GHCR manually. The org has a standard CI pattern (BeaverHouse/cicd `docker-build.yml`) for multi-arch GHCR publishing. Adopt it here so deploys come from CI and arm64 images are available.

## What

- New `.github/workflows/docker-build.yml`: `workflow_dispatch` trigger, separate `amd64` / `arm64` build jobs, registry build cache, multi-arch manifest merge.
- Image stays at `ghcr.io/beaverhouse/ba-data-process`, tagged with the 8-char commit SHA per run.
- Deleted `build.sh`.

## Notes

- GHCR auth uses the built-in `GITHUB_TOKEN` (the workflow runs inside this repo's org, so no PAT needed). Switch to `secrets.GH_PAT_ORGANIZATION` if cross-repo write becomes needed.
- `secrets.GITLAB_TOKEN` is required at the repo level for the Dockerfile's private-module fetch.
- No helm values update step (data-process is batch, not deployed via the tinyclover helm chart).

## Evidence

### Checks
- stack: go-workflow
- base: origin/main
- commit: 82717c4
- scope: whole-repo
- status: pass
- failures: none
