### PR TITLE
fix(ci): authenticate GHCR with org PAT

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.GH_PAT_ORGANIZATION }}
       - uses: docker/build-push-action@v6
         with:
           context: .
@@ -58,7 +58,7 @@ jobs:
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.GH_PAT_ORGANIZATION }}
       - uses: docker/build-push-action@v6
         with:
           context: .
@@ -82,7 +82,7 @@ jobs:
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.GH_PAT_ORGANIZATION }}
       - name: Create and push multi-arch manifest
         run: |
           SHA=${{ needs.generate-sha.outputs.sha }}


### PR DESCRIPTION
## Why

[Run 26414786607](https://github.com/BeaverHouse/ba-torment-data-process/actions/runs/26414786607) (post-merge of #43) failed on both `build-amd64` and `build-arm64`:

```
ERROR: failed to build: failed to solve: failed to push
  ghcr.io/beaverhouse/ba-data-process:878b0ee9-amd64:
  unexpected status from HEAD request to ...: 403 Forbidden
```

Root cause: the repo-scoped `GITHUB_TOKEN` lacks write permission on org-level GHCR packages (`ghcr.io/beaverhouse/*`). #43 used `GITHUB_TOKEN` as a "simplification" — the org standard (BeaverHouse/cicd `docker-build.yml`) uses `GH_PAT_ORGANIZATION` for exactly this reason.

## What

`secrets.GITHUB_TOKEN` → `secrets.GH_PAT_ORGANIZATION` in all three `docker/login-action@v3` steps (`build-amd64`, `build-arm64`, `create-manifest`).

## Evidence

### Checks
- stack: go-workflow
- base: origin/main
- commit: aad3094
- scope: whole-repo
- status: pass
- failures: none

### Verification plan
1. Merge PR.
2. Trigger workflow via `gh workflow run "Build and Push Docker Image"`.
3. Expect all three jobs green, GHCR manifest tag `<sha>` published.
