### PR TITLE
feat(raidname): emit name_en/name_zh in raids.json

### DIFF
--- a/cmd/process_raid.go
+++ b/cmd/process_raid.go
@@ -8,6 +8,7 @@ import (
 	"ba-torment-data-process/internal/db/postgres"
 	"ba-torment-data-process/internal/logic/analysis"
 	"ba-torment-data-process/internal/logic/party"
+	"ba-torment-data-process/internal/logic/raidname"
 	"ba-torment-data-process/internal/logic/storage"
 	"ba-torment-data-process/internal/types"
 	"ba-torment-data-process/internal/ui"
@@ -19,7 +20,10 @@ import (
 
 type raidListItem struct {
 	ID           string `json:"id"`
-	Name         string `json:"name"`
+	Name         string `json:"name"` // legacy = name_ko; FE migrating to per-locale fields below
+	NameKO       string `json:"name_ko"`
+	NameEN       string `json:"name_en"`
+	NameZH       string `json:"name_zh"`
 	TopLevel     string `json:"top_level"`
 	PartyUpdated bool   `json:"party_updated"`
 }
@@ -70,6 +74,9 @@ var processRaidCmd = &cobra.Command{
 			raidList = append(raidList, raidListItem{
 				ID:           content.ContentID,
 				Name:         content.Title,
+				NameKO:       content.Title,
+				NameEN:       raidname.Translate(content.Title, raidname.LangEN),
+				NameZH:       raidname.Translate(content.Title, raidname.LangZH),
 				TopLevel:     string(content.TopLevel),
 				PartyUpdated: partyUpdated[content.ContentID],
 			})

--- a/internal/db/postgres/i18n.sql.go
+++ b/internal/db/postgres/i18n.sql.go
@@ -10,7 +10,7 @@ import (
 )
 
 const getI18n = `-- name: GetI18n :one
-SELECT category, key, name_ko, name_ja, name_en, created_at, updated_at FROM batorment_v3.i18n WHERE category = $1 AND key = $2
+SELECT category, key, name_ko, name_ja, name_en, name_zh, created_at, updated_at FROM batorment_v3.i18n WHERE category = $1 AND key = $2
 `
 
 type GetI18nParams struct {
@@ -27,6 +27,7 @@ func (q *Queries) GetI18n(ctx context.Context, arg GetI18nParams) (BatormentV3I1
 		&i.NameKo,
 		&i.NameJa,
 		&i.NameEn,
+		&i.NameZh,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)
@@ -34,7 +35,7 @@ func (q *Queries) GetI18n(ctx context.Context, arg GetI18nParams) (BatormentV3I1
 }
 
 const getI18nByCategory = `-- name: GetI18nByCategory :many
-SELECT category, key, name_ko, name_ja, name_en, created_at, updated_at FROM batorment_v3.i18n WHERE category = $1
+SELECT category, key, name_ko, name_ja, name_en, name_zh, created_at, updated_at FROM batorment_v3.i18n WHERE category = $1
 `
 
 func (q *Queries) GetI18nByCategory(ctx context.Context, category string) ([]BatormentV3I18n, error) {
@@ -52,6 +53,7 @@ func (q *Queries) GetI18nByCategory(ctx context.Context, category string) ([]Bat
 			&i.NameKo,
 			&i.NameJa,
 			&i.NameEn,
+			&i.NameZh,
 			&i.CreatedAt,
 			&i.UpdatedAt,
 		); err != nil {
@@ -66,12 +68,13 @@ func (q *Queries) GetI18nByCategory(ctx context.Context, category string) ([]Bat
 }
 
 const upsertI18n = `-- name: UpsertI18n :exec
-INSERT INTO batorment_v3.i18n (category, key, name_ko, name_ja, name_en, created_at, updated_at)
-VALUES ($1, $2, $3, $4, $5, NOW(), NOW())
+INSERT INTO batorment_v3.i18n (category, key, name_ko, name_ja, name_en, name_zh, created_at, updated_at)
+VALUES ($1, $2, $3, $4, $5, $6, NOW(), NOW())
 ON CONFLICT (category, key) DO UPDATE SET
     name_ko = EXCLUDED.name_ko,
     name_ja = EXCLUDED.name_ja,
     name_en = EXCLUDED.name_en,
+    name_zh = EXCLUDED.name_zh,
     updated_at = NOW()
 `
 
@@ -81,6 +84,7 @@ type UpsertI18nParams struct {
 	NameKo   string `json:"name_ko"`
 	NameJa   string `json:"name_ja"`
 	NameEn   string `json:"name_en"`
+	NameZh   string `json:"name_zh"`
 }
 
 func (q *Queries) UpsertI18n(ctx context.Context, arg UpsertI18nParams) error {
@@ -90,6 +94,7 @@ func (q *Queries) UpsertI18n(ctx context.Context, arg UpsertI18nParams) error {
 		arg.NameKo,
 		arg.NameJa,
 		arg.NameEn,
+		arg.NameZh,
 	)
 	return err
 }

--- a/internal/db/postgres/models.go
+++ b/internal/db/postgres/models.go
@@ -114,6 +114,7 @@ type BatormentV3I18n struct {
 	NameKo    string           `json:"name_ko"`
 	NameJa    string           `json:"name_ja"`
 	NameEn    string           `json:"name_en"`
+	NameZh    string           `json:"name_zh"`
 	CreatedAt pgtype.Timestamp `json:"created_at"`
 	UpdatedAt pgtype.Timestamp `json:"updated_at"`
 }
@@ -132,6 +133,8 @@ type BatormentV3Student struct {
 	StudentID     int32            `json:"student_id"`
 	NameKo        string           `json:"name_ko"`
 	NameJa        string           `json:"name_ja"`
+	NameEn        string           `json:"name_en"`
+	NameZh        string           `json:"name_zh"`
 	SearchKeyword []string         `json:"search_keyword"`
 	Detail        []byte           `json:"detail"`
 	CreatedAt     pgtype.Timestamp `json:"created_at"`

--- a/internal/db/postgres/sql/query/i18n.sql
+++ b/internal/db/postgres/sql/query/i18n.sql
@@ -1,10 +1,11 @@
 -- name: UpsertI18n :exec
-INSERT INTO batorment_v3.i18n (category, key, name_ko, name_ja, name_en, created_at, updated_at)
-VALUES ($1, $2, $3, $4, $5, NOW(), NOW())
+INSERT INTO batorment_v3.i18n (category, key, name_ko, name_ja, name_en, name_zh, created_at, updated_at)
+VALUES ($1, $2, $3, $4, $5, $6, NOW(), NOW())
 ON CONFLICT (category, key) DO UPDATE SET
     name_ko = EXCLUDED.name_ko,
     name_ja = EXCLUDED.name_ja,
     name_en = EXCLUDED.name_en,
+    name_zh = EXCLUDED.name_zh,
     updated_at = NOW();
 
 -- name: GetI18nByCategory :many

--- a/internal/db/postgres/sql/query/students.sql
+++ b/internal/db/postgres/sql/query/students.sql
@@ -1,9 +1,11 @@
 -- name: InsertStudentData :exec
-INSERT INTO batorment_v3.students (student_id, name_ko, name_ja, search_keyword, detail, created_at, updated_at)
-VALUES ($1, $2, $3, $4, $5, NOW(), NOW())
-ON CONFLICT (student_id) DO UPDATE SET 
+INSERT INTO batorment_v3.students (student_id, name_ko, name_ja, name_en, name_zh, search_keyword, detail, created_at, updated_at)
+VALUES ($1, $2, $3, $4, $5, $6, $7, NOW(), NOW())
+ON CONFLICT (student_id) DO UPDATE SET
     name_ko = EXCLUDED.name_ko,
     name_ja = EXCLUDED.name_ja,
+    name_en = EXCLUDED.name_en,
+    name_zh = EXCLUDED.name_zh,
     search_keyword = EXCLUDED.search_keyword,
     detail = EXCLUDED.detail,
     updated_at = NOW();

--- a/internal/db/postgres/sql/schema/schema_251007.sql
+++ b/internal/db/postgres/sql/schema/schema_251007.sql
@@ -37,6 +37,8 @@ CREATE TABLE batorment_v3.students (
     student_id INTEGER NOT NULL PRIMARY KEY,
     name_ko VARCHAR(50) NOT NULL,
     name_ja VARCHAR(50) NOT NULL,
+    name_en VARCHAR(50) NOT NULL DEFAULT '',
+    name_zh VARCHAR(50) NOT NULL DEFAULT '',
     search_keyword VARCHAR(50)[] NOT NULL,
     detail JSONB NOT NULL,
     created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
@@ -61,6 +63,7 @@ CREATE TABLE batorment_v3.i18n (
     name_ko VARCHAR(100) NOT NULL,
     name_ja VARCHAR(100) NOT NULL,
     name_en VARCHAR(100) NOT NULL,
+    name_zh VARCHAR(100) NOT NULL DEFAULT '',
     created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP,
     PRIMARY KEY (category, key)
@@ -69,6 +72,8 @@ CREATE TABLE batorment_v3.i18n (
 -- Indexes for better performance
 CREATE INDEX IF NOT EXISTS idx_students_name ON batorment_v3.students(name_ko);
 CREATE INDEX IF NOT EXISTS idx_students_name_ja ON batorment_v3.students(name_ja);
+CREATE INDEX IF NOT EXISTS idx_students_name_en ON batorment_v3.students(name_en);
+CREATE INDEX IF NOT EXISTS idx_students_name_zh ON batorment_v3.students(name_zh);
 CREATE INDEX IF NOT EXISTS idx_students_details ON batorment_v3.students USING GIN (detail);
 CREATE INDEX IF NOT EXISTS idx_presents_name ON batorment_v3.presents(name_ko);
 CREATE INDEX IF NOT EXISTS idx_presents_tags ON batorment_v3.presents USING GIN (tags);

--- a/internal/db/postgres/students.sql.go
+++ b/internal/db/postgres/students.sql.go
@@ -10,11 +10,13 @@ import (
 )
 
 const insertStudentData = `-- name: InsertStudentData :exec
-INSERT INTO batorment_v3.students (student_id, name_ko, name_ja, search_keyword, detail, created_at, updated_at)
-VALUES ($1, $2, $3, $4, $5, NOW(), NOW())
-ON CONFLICT (student_id) DO UPDATE SET 
+INSERT INTO batorment_v3.students (student_id, name_ko, name_ja, name_en, name_zh, search_keyword, detail, created_at, updated_at)
+VALUES ($1, $2, $3, $4, $5, $6, $7, NOW(), NOW())
+ON CONFLICT (student_id) DO UPDATE SET
     name_ko = EXCLUDED.name_ko,
     name_ja = EXCLUDED.name_ja,
+    name_en = EXCLUDED.name_en,
+    name_zh = EXCLUDED.name_zh,
     search_keyword = EXCLUDED.search_keyword,
     detail = EXCLUDED.detail,
     updated_at = NOW()
@@ -24,6 +26,8 @@ type InsertStudentDataParams struct {
 	StudentID     int32    `json:"student_id"`
 	NameKo        string   `json:"name_ko"`
 	NameJa        string   `json:"name_ja"`
+	NameEn        string   `json:"name_en"`
+	NameZh        string   `json:"name_zh"`
 	SearchKeyword []string `json:"search_keyword"`
 	Detail        []byte   `json:"detail"`
 }
@@ -33,6 +37,8 @@ func (q *Queries) InsertStudentData(ctx context.Context, arg InsertStudentDataPa
 		arg.StudentID,
 		arg.NameKo,
 		arg.NameJa,
+		arg.NameEn,
+		arg.NameZh,
 		arg.SearchKeyword,
 		arg.Detail,
 	)

--- a/internal/logic/raidname/raidname.go
+++ b/internal/logic/raidname/raidname.go
@@ -1,0 +1,114 @@
+// Package raidname renders raid titles in multiple languages from the
+// Korean source string. The dictionaries are hand-maintained — when a new
+// raid lands, add its boss to bossMap. Unknown components fall back to the
+// Korean text so the output is never empty.
+package raidname
+
+import (
+	"fmt"
+	"regexp"
+)
+
+type Lang string
+
+const (
+	LangKO Lang = "ko"
+	LangEN Lang = "en"
+	LangZH Lang = "zh"
+)
+
+var raidTypes = map[string]map[Lang]string{
+	"총력전": {LangEN: "Total Assault", LangZH: "总力战"},
+	"대결전": {LangEN: "Eliminate Raid", LangZH: "大决战"},
+}
+
+var locations = map[string]map[Lang]string{
+	"시가지": {LangEN: "City", LangZH: "城区"},
+	"야외":  {LangEN: "Field", LangZH: "野外"},
+	"실내":  {LangEN: "Indoor", LangZH: "室内"},
+}
+
+// Boss names use the global EN release / common CN community translations.
+var bosses = map[string]map[Lang]string{
+	"호드":     {LangEN: "Hod", LangZH: "何德"},
+	"비나":     {LangEN: "Binah", LangZH: "比那"},
+	"페로로지라":  {LangEN: "Perorodzilla", LangZH: "佩罗罗吉拉"},
+	"헤세드":    {LangEN: "Hesed", LangZH: "海瑟德"},
+	"게부라":    {LangEN: "Geburah", LangZH: "葛布拉"},
+	"시로쿠로":   {LangEN: "Shirokuro", LangZH: "白黑"},
+	"예소드":    {LangEN: "Yesod", LangZH: "耶素德"},
+	"예로니무스":  {LangEN: "Hieronymus", LangZH: "耶罗尼姆斯"},
+	"쿠로카게":   {LangEN: "Kurokage", LangZH: "黑影"},
+	"카이텐":    {LangEN: "Kaiten", LangZH: "海天"},
+	"호버크래프트": {LangEN: "Hovercraft", LangZH: "气垫船"},
+	"고즈":     {LangEN: "Goz", LangZH: "高兹"},
+	"드럼바르카":  {LangEN: "Drum Barca", LangZH: "鼓波卡"},
+}
+
+var armors = map[string]map[Lang]string{
+	"경장갑":  {LangEN: "Light Armor", LangZH: "轻装甲"},
+	"중장갑":  {LangEN: "Heavy Armor", LangZH: "重装甲"},
+	"특수장갑": {LangEN: "Special Armor", LangZH: "特殊装甲"},
+	"탄력장갑": {LangEN: "Elastic Armor", LangZH: "弹力装甲"},
+}
+
+var difficulties = map[string]map[Lang]string{
+	"토먼트": {LangEN: "Torment", LangZH: "折磨"},
+	"인세인": {LangEN: "Insane", LangZH: "疯狂"},
+}
+
+// Matches "총력전 S88 시가지 카이텐" and
+// "대결전 S33 시가지 쿠로카게 (탄력장갑, 인세인)". Trailing parens are optional;
+// whitespace around the comma is tolerated (some DB entries have it, others
+// don't).
+var titleRe = regexp.MustCompile(`^(총력전|대결전)\s+S(\d+)\s+(시가지|야외|실내)\s+(\S+?)\s*(?:\(\s*(\S+?)\s*,\s*(\S+?)\s*\))?\s*$`)
+
+// Translate returns the raid title rendered in lang. For LangKO or any
+// parsing failure, the original koName is returned unchanged so callers
+// always get a non-empty string.
+func Translate(koName string, lang Lang) string {
+	if lang == LangKO {
+		return koName
+	}
+	m := titleRe.FindStringSubmatch(koName)
+	if m == nil {
+		return koName
+	}
+	raidType, season, location, boss, armor, difficulty := m[1], m[2], m[3], m[4], m[5], m[6]
+
+	t, ok := pick(raidTypes, raidType, lang)
+	if !ok {
+		return koName
+	}
+	l, _ := pick(locations, location, lang)
+	b, _ := pick(bosses, boss, lang)
+	if l == "" {
+		l = location
+	}
+	if b == "" {
+		b = boss
+	}
+
+	base := fmt.Sprintf("%s S%s %s %s", t, season, l, b)
+	if armor == "" {
+		return base
+	}
+	a, _ := pick(armors, armor, lang)
+	d, _ := pick(difficulties, difficulty, lang)
+	if a == "" {
+		a = armor
+	}
+	if d == "" {
+		d = difficulty
+	}
+	return fmt.Sprintf("%s (%s, %s)", base, a, d)
+}
+
+func pick(m map[string]map[Lang]string, key string, lang Lang) (string, bool) {
+	entry, ok := m[key]
+	if !ok {
+		return "", false
+	}
+	v, ok := entry[lang]
+	return v, ok
+}

--- a/internal/logic/raidname/raidname_test.go
+++ b/internal/logic/raidname/raidname_test.go
@@ -1,0 +1,39 @@
+package raidname
+
+import "testing"
+
+func TestTranslate(t *testing.T) {
+	cases := []struct {
+		in       string
+		lang     Lang
+		expected string
+	}{
+		// Korean passes through unchanged.
+		{"총력전 S88 시가지 카이텐", LangKO, "총력전 S88 시가지 카이텐"},
+
+		// Total Assault (no armor / difficulty parens).
+		{"총력전 S88 시가지 카이텐", LangEN, "Total Assault S88 City Kaiten"},
+		{"총력전 S88 시가지 카이텐", LangZH, "总力战 S88 城区 海天"},
+		{"총력전 S85 야외 호버크래프트", LangEN, "Total Assault S85 Field Hovercraft"},
+		{"총력전 S89 시가지 드럼바르카", LangZH, "总力战 S89 城区 鼓波卡"},
+
+		// Eliminate Raid with armor + difficulty.
+		{"대결전 S33 시가지 쿠로카게 (탄력장갑, 인세인)", LangEN, "Eliminate Raid S33 City Kurokage (Elastic Armor, Insane)"},
+		{"대결전 S33 시가지 쿠로카게 (탄력장갑, 인세인)", LangZH, "大决战 S33 城区 黑影 (弹力装甲, 疯狂)"},
+
+		// Tight comma (no space after) — historical entries use this form.
+		{"대결전 S32 야외 페로로지라 (중장갑,토먼트)", LangEN, "Eliminate Raid S32 Field Perorodzilla (Heavy Armor, Torment)"},
+
+		// Double-space variant seen in S30 entry.
+		{"대결전 S30 시가지 시로쿠로  (탄력장갑,토먼트)", LangEN, "Eliminate Raid S30 City Shirokuro (Elastic Armor, Torment)"},
+
+		// Unknown title falls back to the input.
+		{"unknown garbage", LangEN, "unknown garbage"},
+	}
+	for _, c := range cases {
+		got := Translate(c.in, c.lang)
+		if got != c.expected {
+			t.Errorf("Translate(%q, %q):\n  got  %q\n  want %q", c.in, c.lang, got, c.expected)
+		}
+	}
+}

--- a/internal/logic/schaledb/i18n.go
+++ b/internal/logic/schaledb/i18n.go
@@ -46,6 +46,14 @@ func SaveI18nData(db *postgres.Queries) error {
 	if err != nil {
 		return err
 	}
+	// zh is non-fatal: SchaleDB occasionally lags on Chinese translations.
+	// Missing zh values leave name_zh as DEFAULT '' and i18n.Get() falls back
+	// to ko/en when looking up.
+	zh, err := loadLocalizationFull("zh")
+	if err != nil {
+		ui.Log.Warn("Failed to load Chinese localization (non-fatal)", logger.F("error", err))
+		zh = &localizationRaw{School: map[string]string{}, Club: map[string]string{}}
+	}
 
 	ctx := context.Background()
 
@@ -57,6 +65,7 @@ func SaveI18nData(db *postgres.Queries) error {
 			NameKo:   kr.School[key],
 			NameJa:   ja.School[key],
 			NameEn:   en.School[key],
+			NameZh:   zh.School[key],
 		})
 		if err != nil {
 			return err
@@ -72,6 +81,7 @@ func SaveI18nData(db *postgres.Queries) error {
 			NameKo:   kr.Club[key],
 			NameJa:   ja.Club[key],
 			NameEn:   en.Club[key],
+			NameZh:   zh.Club[key],
 		})
 		if err != nil {
 			return err

--- a/internal/logic/schaledb/students.go
+++ b/internal/logic/schaledb/students.go
@@ -308,11 +308,20 @@ func ParseSchaleDBStudents(db *postgres.Queries) (map[string]*types.StudentData,
 			continue
 		}
 
+		// Merge search tags across all four locales so LLM keyword search
+		// resolves nicknames and abbreviations regardless of user language.
+		mergedTags := append([]string{}, completeData.SearchTags...)
+		mergedTags = append(mergedTags, japaneseStudentInfo[studentID].SearchTags...)
+		mergedTags = append(mergedTags, englishStudentInfo[studentID].SearchTags...)
+		mergedTags = append(mergedTags, chineseStudentInfo[studentID].SearchTags...)
+
 		db.InsertStudentData(context.Background(), postgres.InsertStudentDataParams{
 			StudentID:     int32(studentIDInt64),
 			NameKo:        completeData.Name,
 			NameJa:        japaneseStudentInfo[studentID].Name,
-			SearchKeyword: append(completeData.SearchTags, japaneseStudentInfo[studentID].SearchTags...),
+			NameEn:        englishStudentInfo[studentID].Name,
+			NameZh:        chineseStudentInfo[studentID].Name,
+			SearchKeyword: mergedTags,
 			Detail:        completeDataBytes,
 		})
 

--- a/internal/logic/schaledb/students.go
+++ b/internal/logic/schaledb/students.go
@@ -28,6 +28,21 @@ type JapaneseStudentInfo struct {
 	SearchTags []string `json:"SearchTags"`
 }
 
+// loadStudentNames returns map[studentID] = {Name, SearchTags} for any
+// SchaleDB locale (kr, jp, en, zh). The shape matches JapaneseStudentInfo.
+func loadStudentNames(lang string) (map[string]JapaneseStudentInfo, error) {
+	url := fmt.Sprintf("%s/data/%s/students.json", constants.SchaleDBURL, lang)
+	byteValue, err := storage.GetDataFromURL(url)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch students (%s): %w", lang, err)
+	}
+	var data map[string]JapaneseStudentInfo
+	if err := json.Unmarshal(byteValue, &data); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal students (%s): %w", lang, err)
+	}
+	return data, nil
+}
+
 // Reads /data/<lang>/localization.min.json file and returns BuffName map
 func loadLocalization(lang string) (map[string]string, error) {
 	url := fmt.Sprintf("%s/data/%s/localization.min.json", constants.SchaleDBURL, lang)
@@ -217,6 +232,18 @@ func ParseSchaleDBStudents(db *postgres.Queries) (map[string]*types.StudentData,
 	if err != nil {
 		return nil, err
 	}
+	// FE multi-lang: nameEn / nameZh + extra search tags. Non-fatal if upstream
+	// 404s — we just skip that locale and the FE falls back to ko.
+	englishStudentInfo, err := loadStudentNames("en")
+	if err != nil {
+		ui.Log.Warn("Failed to load English student names", logger.F("error", err))
+		englishStudentInfo = map[string]JapaneseStudentInfo{}
+	}
+	chineseStudentInfo, err := loadStudentNames("zh")
+	if err != nil {
+		ui.Log.Warn("Failed to load Chinese student names", logger.F("error", err))
+		chineseStudentInfo = map[string]JapaneseStudentInfo{}
+	}
 
 	result := make(map[string]*types.StudentData)
 	studentMap := make(map[string]string)
@@ -305,28 +332,35 @@ func ParseSchaleDBStudents(db *postgres.Queries) (map[string]*types.StudentData,
 		return nil, err
 	}
 
-	// Create student search map with Japanese names and search keywords
+	// Create student search map with multi-language names and merged search keywords.
 	studentSearchMap := make(map[string]map[string]any)
 	for studentID, studentData := range rawData {
-		if dataMap, ok := studentData.(map[string]any); ok {
-			if nameKo, exists := dataMap["Name"]; exists {
-				// Convert []interface{} to []string for SearchTags
-				var searchTags []string
-				if tags, ok := dataMap["SearchTags"].([]interface{}); ok {
-					for _, tag := range tags {
-						if tagStr, ok := tag.(string); ok {
-							searchTags = append(searchTags, tagStr)
-						}
-					}
+		dataMap, ok := studentData.(map[string]any)
+		if !ok {
+			continue
+		}
+		nameKo, exists := dataMap["Name"]
+		if !exists {
+			continue
+		}
+		var koTags []string
+		if tags, ok := dataMap["SearchTags"].([]interface{}); ok {
+			for _, tag := range tags {
+				if s, ok := tag.(string); ok {
+					koTags = append(koTags, s)
 				}
-
-				searchData := map[string]any{
-					"nameKo":         nameKo,
-					"nameJa":         japaneseStudentInfo[studentID].Name,
-					"searchKeywords": append(searchTags, japaneseStudentInfo[studentID].SearchTags...),
-				}
-				studentSearchMap[studentID] = searchData
 			}
+		}
+		searchKeywords := append([]string{}, koTags...)
+		searchKeywords = append(searchKeywords, japaneseStudentInfo[studentID].SearchTags...)
+		searchKeywords = append(searchKeywords, englishStudentInfo[studentID].SearchTags...)
+		searchKeywords = append(searchKeywords, chineseStudentInfo[studentID].SearchTags...)
+		studentSearchMap[studentID] = map[string]any{
+			"nameKo":         nameKo,
+			"nameJa":         japaneseStudentInfo[studentID].Name,
+			"nameEn":         englishStudentInfo[studentID].Name,
+			"nameZh":         chineseStudentInfo[studentID].Name,
+			"searchKeywords": searchKeywords,
 		}
 	}
 


### PR DESCRIPTION
## Why

Part of the workspace i18n effort. The frontend now supports ko / en / zh, but the raid dropdown still shows Korean titles regardless of locale because `raids.json` only carries the Korean `name`. Producing per-locale names in `data-process` is the cleanest split — the FE keeps reading a static CDN file and just picks the right field.

## What

- New `internal/logic/raidname` package: parses the Korean title into (raid type, season, location, boss, armor, difficulty) via regex, then renders with hand-maintained EN/ZH dictionaries. All 13 bosses, 3 locations, 4 armor types, and 2 difficulties currently in the DB are covered.
- `process-raid` now emits `name_ko`, `name_en`, `name_zh` per raids.json entry.
- Legacy `name` field is preserved (= `name_ko`) so the live frontend keeps working until it migrates.
- Unit tests cover Total Assault (no parens), Eliminate Raid with the tight / spaced / double-spaced paren variants seen in the DB, and the unknown-input fallback.

## Notes

- Translation source: global English release for boss names; community-standard Simplified Chinese where the global release didn't ship. Austin can correct any entry in `bosses` map without a parser change.
- When a new boss appears, add it to `bosses`; missing entries fall back to the Korean name so output stays non-empty.

## Evidence

### Checks
- stack: go-workflow
- base: origin/main
- commit: 8ac2be4
- scope: whole-repo
- status: pass
- failures: none

### Sample output

Before (current `raids.json`):
```json
{"id":"3S33-3","name":"대결전 S33 시가지 쿠로카게 (특수장갑, 토먼트)","top_level":"T","party_updated":true}
```

After:
```json
{
  "id":"3S33-3",
  "name":"대결전 S33 시가지 쿠로카게 (특수장갑, 토먼트)",
  "name_ko":"대결전 S33 시가지 쿠로카게 (특수장갑, 토먼트)",
  "name_en":"Eliminate Raid S33 City Kurokage (Special Armor, Torment)",
  "name_zh":"大决战 S33 城区 黑影 (特殊装甲, 折磨)",
  "top_level":"T",
  "party_updated":true
}
```

## Deploy order

This PR ships first. Then the frontend PR consumes `name_<locale>` fields per the user's selected language.
