### PR TITLE
fix(i18n): align EN/ZH raid terms with SchaleDB official names

### DIFF
--- a/internal/logic/raidname/raidname.go
+++ b/internal/logic/raidname/raidname.go
@@ -19,29 +19,29 @@ const (
 
 var raidTypes = map[string]map[Lang]string{
 	"총력전": {LangEN: "Total Assault", LangZH: "总力战"},
-	"대결전": {LangEN: "Eliminate Raid", LangZH: "大决战"},
+	"대결전": {LangEN: "Grand Assault", LangZH: "大决战"},
 }
 
 var locations = map[string]map[Lang]string{
-	"시가지": {LangEN: "City", LangZH: "城区"},
-	"야외":  {LangEN: "Field", LangZH: "野外"},
+	"시가지": {LangEN: "Street", LangZH: "街区"},
+	"야외":  {LangEN: "Outdoor", LangZH: "户外"},
 	"실내":  {LangEN: "Indoor", LangZH: "室内"},
 }
 
 // Boss names use the global EN release / common CN community translations.
 var bosses = map[string]map[Lang]string{
-	"호드":     {LangEN: "Hod", LangZH: "何德"},
-	"비나":     {LangEN: "Binah", LangZH: "比那"},
-	"페로로지라":  {LangEN: "Perorodzilla", LangZH: "佩罗罗吉拉"},
-	"헤세드":    {LangEN: "Hesed", LangZH: "海瑟德"},
-	"게부라":    {LangEN: "Geburah", LangZH: "葛布拉"},
-	"시로쿠로":   {LangEN: "Shirokuro", LangZH: "白黑"},
-	"예소드":    {LangEN: "Yesod", LangZH: "耶素德"},
-	"예로니무스":  {LangEN: "Hieronymus", LangZH: "耶罗尼姆斯"},
+	"호드":     {LangEN: "Hod", LangZH: "Hod"},
+	"비나":     {LangEN: "Binah", LangZH: "Binah"},
+	"페로로지라":  {LangEN: "Perorodzilla", LangZH: "佩洛洛斯拉"},
+	"헤세드":    {LangEN: "Chesed", LangZH: "Chesed"},
+	"게부라":    {LangEN: "Geburah", LangZH: "Geburah"},
+	"시로쿠로":   {LangEN: "Shiro & Kuro", LangZH: "白＆黑"},
+	"예소드":    {LangEN: "Yesod", LangZH: "Yesod"},
+	"예로니무스":  {LangEN: "Hieronymus", LangZH: "希罗尼穆斯"},
 	"쿠로카게":   {LangEN: "Kurokage", LangZH: "黑影"},
-	"카이텐":    {LangEN: "Kaiten", LangZH: "海天"},
-	"호버크래프트": {LangEN: "Hovercraft", LangZH: "气垫船"},
-	"고즈":     {LangEN: "Goz", LangZH: "高兹"},
+	"카이텐":    {LangEN: "KAITEN FX Mk.0", LangZH: "KAITEN FX 0型"},
+	"호버크래프트": {LangEN: "Hovercraft", LangZH: "灾厄之狐"},
+	"고즈":     {LangEN: "Goz", LangZH: "戈兹"},
 	"드럼바르카":  {LangEN: "Drum Barca", LangZH: "鼓波卡"},
 }
 

--- a/internal/logic/raidname/raidname_test.go
+++ b/internal/logic/raidname/raidname_test.go
@@ -12,20 +12,20 @@ func TestTranslate(t *testing.T) {
 		{"총력전 S88 시가지 카이텐", LangKO, "총력전 S88 시가지 카이텐"},
 
 		// Total Assault (no armor / difficulty parens).
-		{"총력전 S88 시가지 카이텐", LangEN, "Total Assault S88 City Kaiten"},
-		{"총력전 S88 시가지 카이텐", LangZH, "总力战 S88 城区 海天"},
-		{"총력전 S85 야외 호버크래프트", LangEN, "Total Assault S85 Field Hovercraft"},
-		{"총력전 S89 시가지 드럼바르카", LangZH, "总力战 S89 城区 鼓波卡"},
+		{"총력전 S88 시가지 카이텐", LangEN, "Total Assault S88 Street KAITEN FX Mk.0"},
+		{"총력전 S88 시가지 카이텐", LangZH, "总力战 S88 街区 KAITEN FX 0型"},
+		{"총력전 S85 야외 호버크래프트", LangEN, "Total Assault S85 Outdoor Hovercraft"},
+		{"총력전 S89 시가지 드럼바르카", LangZH, "总力战 S89 街区 鼓波卡"},
 
-		// Eliminate Raid with armor + difficulty.
-		{"대결전 S33 시가지 쿠로카게 (탄력장갑, 인세인)", LangEN, "Eliminate Raid S33 City Kurokage (Elastic Armor, Insane)"},
-		{"대결전 S33 시가지 쿠로카게 (탄력장갑, 인세인)", LangZH, "大决战 S33 城区 黑影 (弹力装甲, 疯狂)"},
+		// Grand Assault with armor + difficulty.
+		{"대결전 S33 시가지 쿠로카게 (탄력장갑, 인세인)", LangEN, "Grand Assault S33 Street Kurokage (Elastic Armor, Insane)"},
+		{"대결전 S33 시가지 쿠로카게 (탄력장갑, 인세인)", LangZH, "大决战 S33 街区 黑影 (弹力装甲, 疯狂)"},
 
 		// Tight comma (no space after) — historical entries use this form.
-		{"대결전 S32 야외 페로로지라 (중장갑,토먼트)", LangEN, "Eliminate Raid S32 Field Perorodzilla (Heavy Armor, Torment)"},
+		{"대결전 S32 야외 페로로지라 (중장갑,토먼트)", LangEN, "Grand Assault S32 Outdoor Perorodzilla (Heavy Armor, Torment)"},
 
 		// Double-space variant seen in S30 entry.
-		{"대결전 S30 시가지 시로쿠로  (탄력장갑,토먼트)", LangEN, "Eliminate Raid S30 City Shirokuro (Elastic Armor, Torment)"},
+		{"대결전 S30 시가지 시로쿠로  (탄력장갑,토먼트)", LangEN, "Grand Assault S30 Street Shiro & Kuro (Elastic Armor, Torment)"},
 
 		// Unknown title falls back to the input.
 		{"unknown garbage", LangEN, "unknown garbage"},


### PR DESCRIPTION
## Summary
- Correct English raid terminology to match Blue Archive Global official names (Grand Assault, Street, Outdoor)
- Correct English boss names to match SchaleDB (Chesed, KAITEN FX Mk.0, Shiro & Kuro)
- Align all 13 Chinese boss names with SchaleDB zh locale data
- Update test expectations accordingly

## Test plan
- [x] lint, type check, tests passed

Generated with Claude Code (https://claude.com/claude-code)