### PR TITLE
fix: Bump Go base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.26.1-bookworm AS builder
+FROM golang:1.26.4-bookworm AS builder
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary

https://github.com/BeaverHouse/ba-torment-data-process/actions/runs/27293405684/job/80619720023

Bump Go base image version to resolve image build crash