### PR TITLE
fix(video): Remove stored analysis URL field

### DIFF
--- a/internal/types/ba_torment.go
+++ b/internal/types/ba_torment.go
@@ -94,7 +94,6 @@ type VideoAnalysisListResponse struct {
 
 // YoutubeAnalysisResult represents the analysis_result JSONB field in youtube_analysis table
 type YoutubeAnalysisResult struct {
-	URL         string   `json:"url"`
 	Score       int      `json:"score"`
 	PartyData   [][6]int `json:"partyData"`
 	SkillOrders []any    `json:"skillOrders"`


### PR DESCRIPTION
## Summary

- Remove unused url from YoutubeAnalysisResult so data-process matches the migrated analysis_result JSON shape.

## Implementation notes

- Party/video matching already uses score and partyData, not url.

## Evidence

- austincli agent check PASS, stack go-workflow, changed files 1, failures none.

## Production checklist

- Deploy after the ba-analyzer migration/backend rollout. This change is compatible with migrated rows where analysis_result.url has been removed.