### PR TITLE
Remove skill orders from analysis type

### DIFF
--- a/internal/types/ba_torment.go
+++ b/internal/types/ba_torment.go
@@ -94,7 +94,6 @@ type VideoAnalysisListResponse struct {
 
 // YoutubeAnalysisResult represents the analysis_result JSONB field in youtube_analysis table
 type YoutubeAnalysisResult struct {
-	Score       int      `json:"score"`
-	PartyData   [][6]int `json:"partyData"`
-	SkillOrders []any    `json:"skillOrders"`
+	Score     int      `json:"score"`
+	PartyData [][6]int `json:"partyData"`
 }


### PR DESCRIPTION
## Summary

- Remove the unused skillOrders field from the BA Torment video analysis JSON type.

## Related issues

None.

## Implementation notes

This is a dead-code cleanup. Data processing was not using skillOrders for logic; the struct now only models score and partyData.

## Evidence

- austincli agent check: PASS
- repo-wide search found no remaining skillOrder/SkillOrder/remainingTime references.

## Production checklist

Can be deployed as a rolling update. No DB change is required for this repo.