### PR TITLE
fix: accept fractional SchaleDB skill values

### DIFF
--- a/internal/types/schaledb_students.go
+++ b/internal/types/schaledb_students.go
@@ -130,7 +130,7 @@ type SkillEffect struct {
 	Restrictions         []SkillRestriction    `json:"Restrictions,omitempty"`
 	Target               []string              `json:"Target,omitempty"`
 	Scale                []int                 `json:"Scale,omitempty"`
-	Value                [][]int               `json:"Value,omitempty"`
+	Value                [][]float64           `json:"Value,omitempty"`
 	AdditionalValue      any                   `json:"AdditionalValue,omitempty"`
 	Stat                 string                `json:"Stat,omitempty"`
 	Duration             int                   `json:"Duration,omitempty"`

--- a/internal/types/schaledb_students_test.go
+++ b/internal/types/schaledb_students_test.go
@@ -1,0 +1,30 @@
+package types
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestStudentDataUnmarshalsFractionalSkillEffectValue(t *testing.T) {
+	const data = `{
+		"Skills": {
+			"Ex": {
+				"Desc": "",
+				"Effects": [{
+					"Type": "Buff",
+					"Value": [[3197, 3676], [3836.3999999999996, 4411.2]]
+				}]
+			}
+		}
+	}`
+
+	var student StudentData
+	if err := json.Unmarshal([]byte(data), &student); err != nil {
+		t.Fatalf("unmarshal student data: %v", err)
+	}
+
+	got := student.Skills.Ex.Effects[0].Value[1][0]
+	if got != 3836.3999999999996 {
+		t.Fatalf("fractional effect value = %v, want 3836.3999999999996", got)
+	}
+}


### PR DESCRIPTION
## Summary

- Preserve fractional skill effect values instead of skipping affected students during SchaleDB import.
- Add a regression test using the fractional EX effect shape from student 20060.

## Verification

Static checks: PASS (changed files: 2).
The Go test suite verifies successful decoding and exact preservation of the fractional value.